### PR TITLE
Update metnavcpexcv for empty line

### DIFF
--- a/mdx/granule_metadata_extractor/processing/process_metnavcpexcv.py
+++ b/mdx/granule_metadata_extractor/processing/process_metnavcpexcv.py
@@ -30,6 +30,9 @@ class ExtractMetnavcpexcvMetadata(ExtractASCIIMetadata):
         lat = []
         lon = []
         for line in lines[num_header_lines:]:
+            # filter empty lines
+            if not line.strip():
+                continue
             #Time_Start,Day_Of_Year,Latitude,Longitude,......
             #51118,229,34.6327332,-118.0740712,......
 


### PR DESCRIPTION
Update for metnavcpexcv because CPEXCV_MetNav_DC8_20220906_R0.ict contains an empty line at the end of the file which breaks current MDX extraction