### PR TITLE
Hotfix for operand incompatibility

### DIFF
--- a/mdx/granule_metadata_extractor/processing/process_legacy.py
+++ b/mdx/granule_metadata_extractor/processing/process_legacy.py
@@ -52,6 +52,7 @@ class ExtractLegacyMetadata(ExtractASCIIMetadata):
         """
         granule_info = self.get_file_lookup(collection_name)
         granule_wnes = granule_info.get('wnes_geometry', {})
+        granule_wnes = {key: float(granule_wnes[key]) for key in granule_wnes.keys()}
 
         self.north = max(self.north, granule_wnes.get('northBoundingCoordinate'))
         self.south = min(self. south, granule_wnes.get('southBoundingCoordinate'))
@@ -63,7 +64,7 @@ class ExtractLegacyMetadata(ExtractASCIIMetadata):
         self.end_time = max(self.end_time, max(temporal))
 
         self.format = granule_info.get('format')
-        self.file_size = granule_info.get('sizeMB')
+        self.file_size = float(granule_info.get('sizeMB'))
         # If granule doesn't have a checksum, we fake it. If legacy dataset needs checksum, we will create
         # dedicated MDX for it.
         self.checksum = granule_info.get('checksum') if granule_info.get('checksum') is not None else \


### PR DESCRIPTION
Expected response (using json package):
```
{'temporal': ['2011-05-11T15:46:12.000Z', '2011-05-11T19:27:55.000Z'], 'wnes_geometry': {'westBoundingCoordinate': -99.165, 'eastBoundingCoordinate': -95.895, 'northBoundingCoordinate': 37.617, 'southBoundingCoordinate': 36.193}, 'sizeMB': 0, 'format': 'Not provided'}
```

erroneous response (using ijson):
```
{'temporal': ['2011-05-11T15:46:12.000Z', '2011-05-11T19:27:55.000Z'], 'wnes_geometry': {'westBoundingCoordinate': Decimal('-99.165'), 'eastBoundingCoordinate': Decimal('-95.895'), 'northBoundingCoordinate': Decimal('37.617'), 'southBoundingCoordinate': Decimal('36.193')}, 'sizeMB': 0, 'format': 'Not provided'}
```

response after mapping update (using ijson)
```
{'temporal': ['2011-05-11T15:46:12.000Z', '2011-05-11T19:27:55.000Z'], 'wnes_geometry': {'westBoundingCoordinate': -99.165, 'eastBoundingCoordinate': -95.895, 'northBoundingCoordinate': 37.617, 'southBoundingCoordinate': 36.193}, 'sizeMB': 0, 'format': 'Not provided'}
```