### PR TITLE
Hotfix/build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG stage
 
 COPY requirements*.txt /tmp/
 
-RUN     pip install -r /tmp/requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN     pip install --upgrade --force-reinstall -r /tmp/requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Only if stage is other than dev
 ADD mdx ${LAMBDA_TASK_ROOT}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 cumulus-process==1.1.0
 xlrd==1.2.0
 h5py==3.8.0


### PR DESCRIPTION
Numpy v2 isn't compatible with v1 builds, so for now, we need to force it to use v1