### PR TITLE
 - Updated code to work with published granules in a single step work…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ ARG stage
 
 COPY requirements*.txt /tmp/
 
-RUN     pip install --upgrade --force-reinstall -r /tmp/requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip install --upgrade --force-reinstall -r /tmp/requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
-# Only if stage is other than dev
 ADD mdx ${LAMBDA_TASK_ROOT}
 
+# Only if stage is other than dev
 RUN if [ "$stage" != "prod" ] ; then  \
      pip install -r /tmp/requirements-dev.txt && \
      python -m pytest --junitxml=./test_results/test_metadata_extractor.xml test; \

--- a/build_push_docker.sh
+++ b/build_push_docker.sh
@@ -27,8 +27,15 @@ function update_lambda_or_skip_local() {
   fi
 }
 
-read -rp 'AWS_PROFILE: ' AWS_PROFILE
-read -rp 'Stack Prefix: ' STACK_PREFIX
+if [[ -z "${AWS_PROFILE}" ]]; then
+  echo $AWS_PROFILE
+  read -rp 'AWS_PROFILE: ' AWS_PROFILE
+fi
+
+if [[ -z "${STACK_PREFIX}" ]]; then
+  read -rp 'STACK_PREFIX: ' STACK_PREFIX
+fi
+
 AWS_ACCOUNT_ID=$(get_account_id $AWS_PROFILE)
 
 

--- a/mdx/test/test_integration_test_gpmodmlpvex.py
+++ b/mdx/test/test_integration_test_gpmodmlpvex.py
@@ -20,17 +20,28 @@ def test_task(mock_fetch, mock_upload,mock_remove, mock_size):
         event = json.loads(f.read())
     process = MDX(input=event.get('input'), config=event.get('config'))
     x = process.process()
-    expected_result = {'granules': [{'granuleId': 'lpvex_SHP_Aranda_ODM_u100915_00.txt',
-                                     'files': [{'bucket': 'foo', 'fileName': 'lpvex_SHP_Aranda_ODM_u100915_00.txt',
-                                                'key': 'test/fixtures/lpvex_SHP_Aranda_ODM_u100915_00.txt'},
-                                               {'bucket': 'foo', 'fileName': 'lpvex_SHP_Aranda_ODM_u100915_00.txt',
-                                                'key': 'lpvex_SHP_Aranda_ODM_u100915_00.txt', 'size': 2225},
-                                               {'bucket': 'foo',
-                                                'fileName': 'lpvex_SHP_Aranda_ODM_u100915_00.txt.cmr.json',
-                                                'key': 'lpvex_SHP_Aranda_ODM_u100915_00.txt.cmr.json', 'size': 1983}]}],
-                       'input': ['s3://foo/lpvex_SHP_Aranda_ODM_u100915_00.txt',
-                                 's3://foo/lpvex_SHP_Aranda_ODM_u100915_00.txt.cmr.json'],
-                       'system_bucket': 'foo'}
+    expected_result = {
+        'granules': [{
+            'granuleId': 'lpvex_SHP_Aranda_ODM_u100915_00.txt',
+            'files': [
+                {
+                    'bucket': 'foo', 'fileName': 'lpvex_SHP_Aranda_ODM_u100915_00.txt',
+                    'key': 'test/fixtures/lpvex_SHP_Aranda_ODM_u100915_00.txt'
+                },
+                {
+                    'bucket': 'foo', 'fileName': 'lpvex_SHP_Aranda_ODM_u100915_00.txt',
+                    'key': 'lpvex_SHP_Aranda_ODM_u100915_00.txt', 'size': 2225
+                },
+                {
+                    'bucket': 'foo',
+                    'fileName': 'lpvex_SHP_Aranda_ODM_u100915_00.txt.cmr.json',
+                    'key': 'lpvex_SHP_Aranda_ODM_u100915_00.txt.cmr.json', 'size': 1983
+                }
+            ]
+        }],
+        'input': ['s3://foo/lpvex_SHP_Aranda_ODM_u100915_00.txt', 's3://foo/lpvex_SHP_Aranda_ODM_u100915_00.txt.cmr.json'],
+        'system_bucket': 'foo'
+    }
     print(x)
     print(expected_result)
     assert (x == expected_result)


### PR DESCRIPTION
 - Only ask for profile and prefix if they are not already set
 - Added new upload function to work with published granules that need a cmr.json generated
 - Remove existing file record on generation
 - Minor formatting updates