### PR TITLE
Fix Zero File Size Bug

### DIFF
--- a/mdx/granule_metadata_extractor/processing/process_lookup.py
+++ b/mdx/granule_metadata_extractor/processing/process_lookup.py
@@ -63,7 +63,7 @@ class ExtractLookupMetadata(MetadataExtractor):
                 "NorthBoundingCoordinate": metadata.get("north", ""),
                 "EastBoundingCoordinate": metadata.get("east", ""),
                 "SouthBoundingCoordinate": metadata.get("south", ""),
-                "SizeMBDataGranule": str(metadata.get("size", 0)),
+                "SizeMBDataGranule": str(metadata.get("sizeMB")),
                 "DataFormat": metadata.get("format", "Not Provided"),
                 "VersionId": version
             }

--- a/mdx/test/test_extract_lookup_metadata_cossirimpacts.py
+++ b/mdx/test/test_extract_lookup_metadata_cossirimpacts.py
@@ -60,7 +60,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 14.57)
 
     #'north': '32.33', 'south': '26.72', 'east': '-82.35', 'west': '-86.571'
     def test_4_get_north(self):

--- a/mdx/test/test_extract_lookup_metadata_er2navimpacts.py
+++ b/mdx/test/test_extract_lookup_metadata_er2navimpacts.py
@@ -58,7 +58,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 4.42)
 
     #NLat=41.8472436,SLat=31.9902709,WLon=-88.6512388,ELon=-79.9146066
     def test_4_get_north(self):

--- a/mdx/test/test_extract_lookup_metadata_glmcierra.py
+++ b/mdx/test/test_extract_lookup_metadata_glmcierra.py
@@ -59,7 +59,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 4.26)
 
     #north,south,east,west = 44.454403, -42.27351, -26.374033, -124.40529
     def test_4_get_north(self):

--- a/mdx/test/test_extract_lookup_metadata_p3metnavimpacts.py
+++ b/mdx/test/test_extract_lookup_metadata_p3metnavimpacts.py
@@ -58,7 +58,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 1.61)
 
     #NLat=39.8275736,SLat=37.4497608,WLon=-84.2645088,ELon=-75.443603
     def test_4_get_north(self):

--- a/mdx/test/test_extract_lookup_metadata_parprbimpacts.py
+++ b/mdx/test/test_extract_lookup_metadata_parprbimpacts.py
@@ -59,7 +59,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 7.16)
 
     #NLat=45.249881744384766,SLat=37.910213470458984,WLon=-75.5810317993164,ELon=-70.19293975830078
     def test_4_get_north(self):

--- a/mdx/test/test_extract_lookup_metadata_raxpolimpacts.py
+++ b/mdx/test/test_extract_lookup_metadata_raxpolimpacts.py
@@ -61,7 +61,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 0.1)
 
     #'north': '42.638', 'south': '41.289', 'east': '-69.761', 'west': '-71.575'
     def test_4_get_north(self):

--- a/mdx/test/test_extract_lookup_metadata_tammsimpacts.py
+++ b/mdx/test/test_extract_lookup_metadata_tammsimpacts.py
@@ -59,7 +59,7 @@ class TestProcessLookup(TestCase):
         """
         file_size = self.str_to_num(self.md['SizeMBDataGranule'])
         self.expected_metadata['SizeMBDataGranule'] = str(file_size)
-        self.assertEqual(file_size, 0)
+        self.assertEqual(file_size, 31.22)
 
     #"north": "38.126", "south": "34.987", "east": "-72.475", "west": "-76.187"
     def test_4_get_north(self):


### PR DESCRIPTION
Should reference a variable called 'sizeMB' and should not contain a default value

Should resolve https://github.com/ghrcdaac/metadata-extractor/issues/223